### PR TITLE
Update field names deprecated and removed in Consul 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ consul_service_checks:
   - id: web-script-check
     name: "Runs script and checks the exit code"
     type: script
-    # required, cannot take arguments
-    script: "/usr/local/bin/myscript"
+    # required, should be an array ["/path/to/cmd", "arg1", "arg2"]
+    args: ["/usr/local/bin/myscript"]
   - id: web-ttl-check
     name: "Stays up for as long as the TTL value, needs to be pinged through the HTTP api"
     type: ttl
@@ -68,7 +68,7 @@ consul_service_checks:
     # required, the ID of the container to run the check in
     docker_container_id: "1d88ad189f4"
     shell: "/bin/bash"
-    script: "/app/local-check.py"
+    args: ["/app/local-check.py"]
 ```
 
 The following variables are also available:

--- a/templates/service.json.j2
+++ b/templates/service.json.j2
@@ -7,7 +7,7 @@
     {% if consul_service_address is defined -%}
     "address": "{{ consul_service_address }}",
     {% endif -%}
-    "enableTagOverride": true,
+    "enable_tag_override": true,
     {% if consul_service_checks is defined -%}
     "checks": [
       {% for check in consul_service_checks -%}
@@ -22,7 +22,7 @@
         {% endif -%}
         {% elif check.type == "script" -%}
         "name": "{{ check.id|default(consul_service_name) }} Script check",
-        "script": {{ check.script | to_json }},
+        "args": {{ check.args | to_json }},
         {% elif check.type == "ttl" -%}
         "name": "{{ check.id|default(consul_service_name) }} TTL check",
         "ttl": {{ check.ttl | to_json }},
@@ -30,7 +30,7 @@
         "name": "{{ check.id|default(consul_service_name) }} Docker check",
         "docker_container_id": {{ check.docker_container_id | to_json }},
         "shell": {{ check.shell | to_json }},
-        "script": {{ check.script | to_json }},
+        "args": {{ check.args | to_json }},
         {% endif -%}
         {% if check.deregister_critical_service_after is defined -%}
         "deregister_critical_service_after": {{ check.deregister_critical_service_after | to_json }},


### PR DESCRIPTION
The following fields were deprecated a few versions before and removed in Consul 1.1.0:

- `enableTagOverride` from service definitions:

> For Consul 0.9.3 and earlier you need to use enableTagOverride. Consul 1.0 supports both enable_tag_override and enableTagOverride but the latter is deprecated and has been removed as of Consul 1.1.

- `script` from check definitions:

> Prior to Consul 1.0, checks used a single Script field to define the command to run, and would always run in a shell. In Consul 1.0, the Args array was added so that checks can be run without a shell. The Script field is deprecated, and you should include the shell in the Args to run under a shell, eg. "args": ["sh", "-c", "..."].

See:

- https://www.consul.io/docs/upgrade-specific.html#consul-1-1-0
- https://www.consul.io/docs/agent/services.html#service-definition
- https://www.consul.io/api/agent/check.html#args
